### PR TITLE
Avoid default behavior conflict on OS X

### DIFF
--- a/app/menu-window.json
+++ b/app/menu-window.json
@@ -247,7 +247,7 @@
             },
             {
                 "label": "Quote",
-                "accelerator": "CmdOrCtrl+Q",
+                "accelerator": "CmdOrCtrl+Shift+Q",
                 "command": "format",
                 "parameters": "quote"
             }


### PR DESCRIPTION
Identical to #21, but on the correct branch this time. Duplicate description follows:

> Expected behavior for an OS X Application is for Cmd+Q to quit the app. As-is, this key combination inserts a quote, not only overriding the expected behavior, but affecting the format of the document unexpectedly. Additionally, adding Shift to this key combo causes it to fall more in line with the pattern of the other format options in the group.