### PR TITLE
separate `inlineMath` and `displayMath` support && monospace font

### DIFF
--- a/app/less/themes/abricotine.less
+++ b/app/less/themes/abricotine.less
@@ -27,7 +27,7 @@
 @ui-dialog-button-focus-background: #00689a;
 @ui-dialog-button-color: #fff;
 @ui-dialog-border-color: #eee;
-@ui-dialog-font-family: Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
+@ui-dialog-font-family: Menlo, Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
 
 // Scrollbars
 @ui-scrollbar-track-color: #e5e5e5;
@@ -40,12 +40,12 @@
 // ======
 
 // Text
-@editor-font-family: Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
+@editor-font-family: Menlo, Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
 @editor-text-color: #1d2426;
 @editor-background-color: #fff;
 
 // Headers
-@editor-header-font-family: "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", "Luxi Sans", sans-serif;
+@editor-header-font-family: Menlo, "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", "Luxi Sans", sans-serif;
 @editor-header-color: #000;
 @editor-header-1-size: 300%;
 @editor-header-2-size: 220%;
@@ -55,7 +55,7 @@
 @editor-header-6-size: 110%;
 
 // Code
-@editor-code-font-family: "Courier New", Courier, "Liberation Mono", monospace;
+@editor-code-font-family: Menlo, "Courier New", Courier, "Liberation Mono", monospace;
 @editor-code-color: #3d2249;
 
 // Quote

--- a/app/less/ui.less
+++ b/app/less/ui.less
@@ -18,7 +18,7 @@
 
     body {
         overflow: hidden;
-        font-family: @ui-font-family;
+        font-family: monospace; // @ui-font-family;
         font-size: @ui-font-size;
         -webkit-user-select: none;
         user-select: none;

--- a/app/menu-window.json
+++ b/app/menu-window.json
@@ -352,9 +352,14 @@
                 "parameters": "codeblock"
             },
             {
-                "label": "Math Formula",
+                "label": "Inline Math Formula",
                 "command": "draw",
-                "parameters": "math"
+                "parameters": "inlineMath"
+            },
+            {
+                "label": "Display Math Formula",
+                "command": "draw",
+                "parameters": "displayMath"
             },
             {
                 "label": "Horizontal Rule",
@@ -615,11 +620,18 @@
                         "checked": "autopreview:anchor"
                     },
                     {
-                        "label": "Math",
+                        "label": "InlineMath",
                         "command": "toggleAutopreview",
-                        "parameters": "math",
+                        "parameters": "inlineMath",
                         "type": "checkbox",
-                        "checked": "autopreview:math"
+                        "checked": "autopreview:inlineMath"
+                    },
+                    {
+                        "label": "DisplayMath",
+                        "command": "toggleAutopreview",
+                        "parameters": "displayMath",
+                        "type": "checkbox",
+                        "checked": "autopreview:displayMath"
                     },
                     {
                         "label": "Iframes",

--- a/app/renderer/cm-extend-autopreview.js
+++ b/app/renderer/cm-extend-autopreview.js
@@ -226,7 +226,31 @@ function autopreview (cm, line, types) {
                     inclusiveRight: true
                 }
             },
-            math: {
+            inlineMath: {
+                regex: /\${1}[^$]+\${1}/g,
+                createElement: function (match) {
+                    var $element = $("<span class='math autopreview-math'>" + match[0] + "</span>");
+                    return $element.get(0);
+                },
+                marker: {
+                    clearOnEnter: false,
+                    handleMouseEvents: true,
+                    inclusiveLeft: true,
+                    inclusiveRight: true
+                },
+                callback: function (textMarker, element) {
+                    var onMathLoaded = function () {
+                        textMarker.changed();
+                    };
+                    window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub, element], [onMathLoaded, undefined]);
+                    textMarker.on("beforeCursorEnter", function () {
+                        if (!doc.somethingSelected()) { // Fix blink on selection
+                            textMarker.clear();
+                        }
+                    });
+                }
+            },
+            displayMath: {
                 regex: /\${2}[^$]+\${2}/gi,
                 createElement: function (match) {
                     var $element = $("<span class='math autopreview-math'>" + match[0] + "</span>");

--- a/app/renderer/cm-extend-markdown.js
+++ b/app/renderer/cm-extend-markdown.js
@@ -308,7 +308,8 @@ function draw(type, url) {
         link: ['[', '](' + url + ')'],
         image: ['![', '](' + url + ')'],
         hr: ['\n***'],
-        math: ["$$", "$$"],
+        inlineMath: ["$ ", " $"],
+        displayMath: ["$$ ", " $$"],
         anchor: ["<a name=\"", "\"></a>"],
         codeblock: ["\n```\n", "\n```"]
     };

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -53,8 +53,8 @@
             jax: ["input/TeX", "output/HTML-CSS"],
             extensions: ["tex2jax.js", "CHTML-preview.js", "TeX/AMSmath.js", "TeX/AMSsymbols.js", "TeX/noErrors.js", "TeX/noUndefined.js"],
             tex2jax: {
-                inlineMath: [ ['$$','$$'] ],
-                displayMath: [ ]
+                inlineMath: [ ['$','$'] ],
+                displayMath: [ ['$$', '$$'] ]
             },
             showProcessingMessages: false,
             messageStyle: "none",


### PR DESCRIPTION
Inline math syntax: $ x $  
Display math syntax: $$ x $$

I think monospace font is better when writing markdown, so I modified it.  
**Don't fully merge** if you don't like monospace font. :-)