### PR TITLE
Recent docs

### DIFF
--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -41,6 +41,12 @@ AbrApplication.prototype = {
                 app.addRecentDocument(recentPaths[0]);
             }
             this.menu.setRecentDocsMenu(recentPaths);
+
+            for (var winId in this.windows) {
+                if (!this.windows.hasOwnProperty(winId)) continue;
+                var abrWin = this.windows[winId];
+                abrWin.menu.setRecentDocsMenu(recentPaths);
+            }
         }
     },
 

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -31,29 +31,13 @@ AbrApplication.prototype = {
     // trigger
     setWinPath: function (path, winId) {
         this.windows[winId].path = path;
-        this.storeRecentPath(path, winId);
     },
 
-    storeRecentPath: function (path, winId) {
-        //TODO recent-docs: storing does not work for the first opened doc
+    storeRecentPath: function (path) {
         if (path) {
             // Works only on Windows and MacOS
             // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
             app.addRecentDocument(path);
-
-            var max = this.getConfig("recent-docs:max", winId);
-            if (!max) max = 5;
-            var recentPaths = this.getConfig("recent-docs:files", winId);
-            if (!recentPaths) recentPaths = [];
-            var indexOfPath = recentPaths.indexOf(path);
-            if (indexOfPath >= 0) {
-                recentPaths.splice(indexOfPath, 1);
-            }
-            recentPaths.unshift(path);
-            if (recentPaths.length > max) {
-                recentPaths = recentPaths.slice(0, max);
-            }
-            this.setConfig({"recent-docs:files": recentPaths}, winId);
         }
     },
 

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -36,8 +36,6 @@ AbrApplication.prototype = {
     updateRecentPaths: function (recentPaths) {
         if (recentPaths) {
             if (recentPaths.length > 0) {
-                // May not work on all OS'es (electron doc says Windows and MacOS are OK, tests on Ubuntu 16 show it is OK too)
-                // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
                 app.addRecentDocument(recentPaths[0]);
             }
 
@@ -52,20 +50,12 @@ AbrApplication.prototype = {
             if (!this.windows.hasOwnProperty(winId)) continue;
             var abrWin = this.windows[winId];
             if (abrWin) {
-                // There are some cases when abrWin is null:
-                // Scenario 1: using menu "File > Close Document" on Windows that has no doc
-                // Scenario 2:
-                //      1. Start Abricotine ==> Opens a new empty window
-                //      2. Open one of the recent files using the "File > Recent" menu ==> Selected doc is opened in a new window (unlike the "File > Open menu")
-                //      3. Close the empty window (the one opened when Abricotine started)
-                //      4. Return the window opened at step 2, open a file using the "File > Open" menu
                 abrWin.menu.setRecentDocsMenu(recentPaths);
             }
         }
     },
 
     clearRecentDocs: function(abrWin) {
-        // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
         app.clearRecentDocuments();
         // update storage
         var webContents = abrWin.browserWindow.webContents;

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -36,7 +36,7 @@ AbrApplication.prototype = {
     updateRecentPaths: function (recentPaths) {
         if (recentPaths) {
             if (recentPaths.length > 0) {
-                // Works only on Windows and MacOS
+                // May not work on all OS'es (electron doc says Windows and MacOS are OK, tests on Ubuntu 16 show it is OK too)
                 // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
                 app.addRecentDocument(recentPaths[0]);
             }
@@ -51,8 +51,16 @@ AbrApplication.prototype = {
         for (var winId in this.windows) {
             if (!this.windows.hasOwnProperty(winId)) continue;
             var abrWin = this.windows[winId];
-            // FIXCC recent-docs: error here when opening a file that is in the recent list but using the "File > Open" menu
-            abrWin.menu.setRecentDocsMenu(recentPaths);
+            if (abrWin) {
+                // There are some cases when abrWin is null:
+                // Scenario 1: using menu "File > Close Document" on Windows that has no doc
+                // Scenario 2:
+                //      1. Start Abricotine ==> Opens a new empty window
+                //      2. Open one of the recent files using the "File > Recent" menu ==> Selected doc is opened in a new window (unlike the "File > Open menu")
+                //      3. Close the empty window (the one opened when Abricotine started)
+                //      4. Return the window opened at step 2, open a file using the "File > Open" menu
+                abrWin.menu.setRecentDocsMenu(recentPaths);
+            }
         }
     },
 

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -40,17 +40,26 @@ AbrApplication.prototype = {
                 // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
                 app.addRecentDocument(recentPaths[0]);
             }
-            this.menu.setRecentDocsMenu(recentPaths);
 
-            for (var winId in this.windows) {
-                if (!this.windows.hasOwnProperty(winId)) continue;
-                var abrWin = this.windows[winId];
-                abrWin.menu.setRecentDocsMenu(recentPaths);
-            }
+            this.updateRecentPathsMenus(recentPaths);
+        }
+    },
+
+    updateRecentPathsMenus: function(recentPaths) {
+        this.menu.setRecentDocsMenu(recentPaths);
+
+        for (var winId in this.windows) {
+            if (!this.windows.hasOwnProperty(winId)) continue;
+            var abrWin = this.windows[winId];
+            // FIXCC recent-docs: error here when opening a file that is in the recent list but using the "File > Open" menu
+            abrWin.menu.setRecentDocsMenu(recentPaths);
         }
     },
 
     clearRecentDocs: function(abrWin) {
+        // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
+        app.clearRecentDocuments();
+        // update storage
         var webContents = abrWin.browserWindow.webContents;
         webContents.send("command", "clearRecentDocs");
     },

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -30,6 +30,25 @@ AbrApplication.prototype = {
     // trigger
     setWinPath: function (path, winId) {
         this.windows[winId].path = path;
+        this.storeRecentPath(path, winId);
+    },
+
+    storeRecentPath: function (path, winId) {
+        if (path) {
+            var max = this.getConfig("recent-docs:max", winId);
+            if (!max) max = 5;
+            var recentPaths = this.getConfig("recent-docs:files", winId);
+            if (!recentPaths) recentPaths = [];
+            var indexOfPath = recentPaths.indexOf(path);
+            if (indexOfPath >= 0) {
+                recentPaths.splice(indexOfPath, 1);
+            }
+            recentPaths.unshift(path);
+            if (recentPaths.length > max) {
+                recentPaths = recentPaths.slice(0, max);
+            }
+            this.setConfig({"recent-docs:files": recentPaths}, winId);
+        }
     },
 
     // trigger

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -33,11 +33,14 @@ AbrApplication.prototype = {
         this.windows[winId].path = path;
     },
 
-    storeRecentPath: function (path) {
-        if (path) {
-            // Works only on Windows and MacOS
-            // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
-            app.addRecentDocument(path);
+    updateRecentPaths: function (recentPaths) {
+        if (recentPaths) {
+            if (recentPaths.length > 0) {
+                // Works only on Windows and MacOS
+                // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
+                app.addRecentDocument(recentPaths[0]);
+            }
+            this.menu.setRecentDocsMenu(recentPaths);
         }
     },
 

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -6,7 +6,7 @@
 
 var AbrMenu = require.main.require("./abr-menu.js"),
     AbrWindow = require.main.require("./abr-window.js"),
-    app = require.main.require("app"),
+    app = require.main.require("electron").app,
     BrowserWindow = require("electron").BrowserWindow,
     commands = require.main.require("./commands-main.js"),
     files = require.main.require("./files.js"),

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -6,6 +6,7 @@
 
 var AbrMenu = require.main.require("./abr-menu.js"),
     AbrWindow = require.main.require("./abr-window.js"),
+    app = require.main.require("app"),
     BrowserWindow = require("electron").BrowserWindow,
     commands = require.main.require("./commands-main.js"),
     files = require.main.require("./files.js"),
@@ -36,6 +37,10 @@ AbrApplication.prototype = {
     storeRecentPath: function (path, winId) {
         //TODO recent-docs: storing does not work for the first opened doc
         if (path) {
+            // Works only on Windows and MacOS
+            // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
+            app.addRecentDocument(path);
+
             var max = this.getConfig("recent-docs:max", winId);
             if (!max) max = 5;
             var recentPaths = this.getConfig("recent-docs:files", winId);

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -34,6 +34,7 @@ AbrApplication.prototype = {
     },
 
     storeRecentPath: function (path, winId) {
+        //TODO recent-docs: storing does not work for the first opened doc
         if (path) {
             var max = this.getConfig("recent-docs:max", winId);
             if (!max) max = 5;

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -50,6 +50,12 @@ AbrApplication.prototype = {
         }
     },
 
+    clearRecentDocs: function(abrWin) {
+        console.log("clearRecentDocs " + abrWin.browserWindow.id);
+        var webContents = abrWin.browserWindow.webContents;
+        webContents.send("command", "clearRecentDocs");
+    },
+
     // trigger
     getPathToLoad: function (arg, winId, callback) {
         var win = this.getFocusedAbrWindow(winId),

--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -51,7 +51,6 @@ AbrApplication.prototype = {
     },
 
     clearRecentDocs: function(abrWin) {
-        console.log("clearRecentDocs " + abrWin.browserWindow.id);
         var webContents = abrWin.browserWindow.webContents;
         webContents.send("command", "clearRecentDocs");
     },

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -209,7 +209,7 @@ AbrMenu.prototype = {
     clearRecentDocs: function () {
         // TODO recent-docs: clear recent docs menu
         // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
-        console.log("clearRecentDocs");
+        this.abrWin.abrApp.clearRecentDocs(this.abrWin);
     },
 
     setRecentDocsMenu: function(recentPaths) {

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -203,12 +203,10 @@ AbrMenu.prototype = {
 
     openRecentDoc: function (recentFile) {
         this.abrWin.abrApp.open(recentFile);
-        // TODO recent-docs FIXME Recent doc list is not updated after re-opening a recent file
+        // FIXCC recent-docs: Recent doc list is not updated after re-opening a recent file
     },
 
     clearRecentDocs: function () {
-        // TODO recent-docs: clear recent docs menu
-        // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
         this.abrWin.abrApp.clearRecentDocs(this.abrWin);
     },
 

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -237,7 +237,7 @@ AbrMenu.prototype = {
 
         // append "clear recent" item
         submenu.append(new MenuItem({
-            label: "clear",
+            label: "Clear",
             enabled: (recentPaths.length > 0),
             click: function() {
                 that.clearRecentDocs();

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -202,8 +202,8 @@ AbrMenu.prototype = {
     },
 
     openRecentDoc: function (recentFile) {
-        // TODO recent-docs: open a recent doc
-        console.log("openRecentDoc: " + recentFile);
+        this.abrWin.abrApp.open(recentFile);
+        // TODO recent-docs FIXME Recent doc list is not updated after re-opening a recent file
     },
 
     clearRecentDocs: function () {

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -208,6 +208,7 @@ AbrMenu.prototype = {
 
     clearRecentDocs: function () {
         // TODO recent-docs: clear recent docs menu
+        // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
         console.log("clearRecentDocs");
     },
 

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -203,7 +203,7 @@ AbrMenu.prototype = {
 
     openRecentDoc: function (recentFile) {
         this.abrWin.abrApp.open(recentFile);
-        // FIXCC recent-docs: Recent doc list is not updated after re-opening a recent file
+        // FIXCC recent-docs: Recent doc list is not updated after re-opening a recent file (using the recent menu)
     },
 
     clearRecentDocs: function () {

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -203,7 +203,6 @@ AbrMenu.prototype = {
 
     openRecentDoc: function (recentFile) {
         this.abrWin.abrApp.open(recentFile);
-        // FIXCC recent-docs: Recent doc list is not updated after re-opening a recent file (using the recent menu)
     },
 
     clearRecentDocs: function () {

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -9,6 +9,7 @@ var constants = require.main.require("./constants"),
     fs = require("fs"),
     langmap = require("langmap"),
     Menu = require("electron").Menu,
+    MenuItem = require("electron").MenuItem,
     pathModule = require("path"),
     spellchecker = require('spellchecker');
 
@@ -200,9 +201,49 @@ AbrMenu.prototype = {
         Menu.setApplicationMenu(this.menu);
     },
 
+    openRecentDoc: function (recentFile) {
+        // TODO recent-docs: open a recent doc
+        console.log("openRecentDoc: " + recentFile);
+    },
+
+    clearRecentDocs: function () {
+        // TODO recent-docs: clear recent docs menu
+        console.log("clearRecentDocs");
+    },
+
     setRecentDocsMenu: function(recentPaths) {
-        // TODO recent-docs: update recent docs menu
-        // var submenu = this.findItem("recentDocs").submenu;
+        var submenu = this.findItem("recentDocs").submenu, i, itemData, that = this;
+
+        // clear menu (this API is not public and may change between Electron releases)
+        submenu.clear();
+
+        function createOpenRecentCallback(recent) {
+            return function() {
+                that.openRecentDoc(recent);
+            };
+        }
+
+        // create items for recent files
+        for (i=0; i <recentPaths.length; i++) {
+            itemData = {
+                label: recentPaths[i],
+                click: createOpenRecentCallback(recentPaths[i])
+            };
+            submenu.append(new MenuItem(itemData));
+        }
+
+        submenu.append(new MenuItem({
+            type: "separator"
+        }));
+
+        // append "clear recent" item
+        submenu.append(new MenuItem({
+            label: "clear",
+            enabled: (recentPaths.length > 0),
+            click: function() {
+                that.clearRecentDocs();
+            }
+        }));
     }
 };
 

--- a/app/abr-menu.js
+++ b/app/abr-menu.js
@@ -176,17 +176,18 @@ AbrMenu.prototype = {
             var items = menu.items,
                 menuItem;
             for (var i=0; i <items.length; i++) {
-                if (items[i].submenu) {
+                if (items[i].id === id) {
+                    menuItem = items[i];
+                }
+                else if (items[i].submenu) {
                     menuItem = doFindItem(items[i].submenu, id);
-                } else {
-                    menuItem = items[i].id === id ? items[i] : undefined;
                 }
                 if (menuItem) {
                     return menuItem;
                 }
             }
         }
-        return doFindItem(this, id);
+        return doFindItem(this.menu, id);
     },
 
     popup: function () {
@@ -197,6 +198,11 @@ AbrMenu.prototype = {
     attach: function () {
         // FIXME: use win.setMenu(menu) for Linux and Windows instead
         Menu.setApplicationMenu(this.menu);
+    },
+
+    setRecentDocsMenu: function(recentPaths) {
+        // TODO recent-docs: update recent docs menu
+        // var submenu = this.findItem("recentDocs").submenu;
     }
 };
 

--- a/app/abr-window.js
+++ b/app/abr-window.js
@@ -110,6 +110,8 @@ AbrWindow.prototype = {
             }
         };
 
+        this.abrApp.storeRecentPath(this.path, this.id);
+
         // Set event handlers
         win.webContents.on("dom-ready", function () {
             execStartupCommands();

--- a/app/abr-window.js
+++ b/app/abr-window.js
@@ -110,8 +110,6 @@ AbrWindow.prototype = {
             }
         };
 
-        this.abrApp.storeRecentPath(this.path, this.id);
-
         // Set event handlers
         win.webContents.on("dom-ready", function () {
             execStartupCommands();

--- a/app/abr-window.js
+++ b/app/abr-window.js
@@ -54,6 +54,9 @@ function AbrWindow (abrApp, path) {
     // Context
     this.contextMenu = new AbrMenu(abrApp, this, contextMenuTemplate, this.config);
     this.open();
+    
+    // FIXCC recent-docs: Recent doc list is not updated after re-opening a recent file (using the recent menu)
+    // need trigger abrDoc.updateRecentPath to IPC client
 }
 
 AbrWindow.prototype = {
@@ -128,9 +131,11 @@ AbrWindow.prototype = {
         win.loadURL("file://" + constants.path.window);
 
         // Open devtools on debug mode
-        if (this.config.get("debug")) {
+        if (true || this.config.get("debug")) {
             win.openDevTools();
         }
+        
+        win.send('updateRecentPath', {path: this.path});
     }
 };
 

--- a/app/abr-window.js
+++ b/app/abr-window.js
@@ -131,7 +131,7 @@ AbrWindow.prototype = {
         win.loadURL("file://" + constants.path.window);
 
         // Open devtools on debug mode
-        if (true || this.config.get("debug")) {
+        if (this.config.get("debug")) {
             win.openDevTools();
         }
         

--- a/app/menu-window.json
+++ b/app/menu-window.json
@@ -69,6 +69,19 @@
                 "permanent": true
             },
             {
+                "label": "Recent",
+                "id": "recentDocs",
+                "submenu": [
+                    {
+                    "type": "separator"
+                    },
+                    {
+                        "label": "Clear",
+                        "command": "clearRecentDocList"
+                    }
+                ]
+            },
+            {
                 "type": "separator"
             },
             {

--- a/app/menu-window.json
+++ b/app/menu-window.json
@@ -71,15 +71,7 @@
             {
                 "label": "Recent",
                 "id": "recentDocs",
-                "submenu": [
-                    {
-                    "type": "separator"
-                    },
-                    {
-                        "label": "Clear",
-                        "command": "clearRecentDocList"
-                    }
-                ]
+                "submenu": []
             },
             {
                 "type": "separator"

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -175,8 +175,6 @@ function AbrDocument (theLocalStorage) {
             }
         };
     });
-
-    this.updateRecentPath();
 }
 
 AbrDocument.prototype = {
@@ -191,6 +189,7 @@ AbrDocument.prototype = {
         this.setClean();
         this.updateWindowTitle();
         this.cm.refresh(); // CodeMirror scrollbar bug workaround
+        this.updateRecentPath(path);
     },
 
     close: function (force) {

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -564,9 +564,9 @@ AbrDocument.prototype = {
             }
 
             thisDoc.localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
-        });
 
-        this.ipcClient.trigger("storeRecentPath", path);
+            thisDoc.ipcClient.trigger("updateRecentPaths", recentPaths);
+        });
     },
 };
 

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -570,6 +570,16 @@ AbrDocument.prototype = {
             thisDoc.ipcClient.trigger("updateRecentPaths", recentPaths);
         });
     },
+
+    clearRecentDocs: function() {
+        var thisDoc = this;
+
+        this.getConfig(undefined, function(theConfig) {
+            var recentPaths = [];
+            thisDoc.localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
+            thisDoc.ipcClient.trigger("updateRecentPaths", recentPaths);
+        });
+    }
 };
 
 module.exports = AbrDocument;

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -175,6 +175,8 @@ function AbrDocument (theLocalStorage) {
             }
         };
     });
+
+    this.updateRecentPath();
 }
 
 AbrDocument.prototype = {
@@ -288,7 +290,7 @@ AbrDocument.prototype = {
         if (!path) {
             return false;
         }
-        this.storeRecentPath(path);
+        this.updateRecentPath(path);
         var that = this;
         if (!this.path && this.isClean()) {
             files.readFile(path, function (data, path) {
@@ -310,7 +312,7 @@ AbrDocument.prototype = {
 
     save: function (path, callback) {
         path = path || this.path;
-        this.storeRecentPath(path);
+        this.updateRecentPath(path);
         if (!path) {
             return this.saveAs(callback);
         }
@@ -534,7 +536,7 @@ AbrDocument.prototype = {
         dialogs.about();
     },
 
-    storeRecentPath: function (path) {
+    updateRecentPath: function (path) {
         var thisDoc = this;
 
         this.getConfig(undefined, function(theConfig) {
@@ -553,13 +555,15 @@ AbrDocument.prototype = {
             }
             if (!recentPaths) recentPaths = [];
 
-            var indexOfPath = recentPaths.indexOf(path);
-            if (indexOfPath >= 0) {
-                recentPaths.splice(indexOfPath, 1);
-            }
-            recentPaths.unshift(path);
-            if (recentPaths.length > max) {
-                recentPaths = recentPaths.slice(0, max);
+            if (path) {
+                var indexOfPath = recentPaths.indexOf(path);
+                if (indexOfPath >= 0) {
+                    recentPaths.splice(indexOfPath, 1);
+                }
+                recentPaths.unshift(path);
+                if (recentPaths.length > max) {
+                    recentPaths = recentPaths.slice(0, max);
+                }
             }
 
             thisDoc.localStorage.setItem("recent-docs", JSON.stringify(recentPaths));

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -538,9 +538,7 @@ AbrDocument.prototype = {
     updateRecentPath: function (path) {
         var thisDoc = this;
 
-        this.getConfig(undefined, function(theConfig) {
-
-            var max = theConfig.editor["max-recent"];
+        this.getConfig("editor:max-recent", function(max) {
 
             var recentPaths = thisDoc.localStorage.getItem("recent-docs");
             if (recentPaths) {

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -567,14 +567,10 @@ AbrDocument.prototype = {
     },
 
     clearRecentDocs: function() {
-        var thisDoc = this;
-
-        this.getConfig(undefined, function(theConfig) {
-            var recentPaths = [];
-            localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
-            thisDoc.ipcClient.trigger("updateRecentPaths", recentPaths);
-        });
-    }
+        var recentPaths = [];
+        localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
+        this.ipcClient.trigger("updateRecentPaths", recentPaths);
+   }
 };
 
 module.exports = AbrDocument;

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -536,7 +536,7 @@ AbrDocument.prototype = {
     updateRecentPath: function (path) {
         var thisDoc = this;
 
-        this.getConfig("editor:max-recent", function(max) {
+        this.getConfig("max-recent", function(max) {
 
             var recentPaths = localStorage.getItem("recent-docs");
             if (recentPaths) {

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -538,7 +538,6 @@ AbrDocument.prototype = {
         var thisDoc = this;
 
         this.getConfig(undefined, function(theConfig) {
-            console.log("storeRecentPath");
 
             var max = theConfig.editor["max-recent"];
             if (!max) max = 5;

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -542,7 +542,6 @@ AbrDocument.prototype = {
         this.getConfig(undefined, function(theConfig) {
 
             var max = theConfig.editor["max-recent"];
-            if (!max) max = 5;
 
             var recentPaths = thisDoc.localStorage.getItem("recent-docs");
             if (recentPaths) {

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -19,10 +19,8 @@ var remote = require("electron").remote,
     shell = require("electron").shell,
     spellchecker = require('spellchecker');
 
-function AbrDocument (theLocalStorage) {
+function AbrDocument () {
     var that = this;
-
-    this.localStorage = theLocalStorage;
 
     // IPC init
     var ipcClient = this.ipcClient = new IpcClient();
@@ -540,7 +538,7 @@ AbrDocument.prototype = {
 
         this.getConfig("editor:max-recent", function(max) {
 
-            var recentPaths = thisDoc.localStorage.getItem("recent-docs");
+            var recentPaths = localStorage.getItem("recent-docs");
             if (recentPaths) {
                 try {
                     recentPaths = JSON.parse(recentPaths);
@@ -562,7 +560,7 @@ AbrDocument.prototype = {
                 }
             }
 
-            thisDoc.localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
+            localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
 
             thisDoc.ipcClient.trigger("updateRecentPaths", recentPaths);
         });
@@ -573,7 +571,7 @@ AbrDocument.prototype = {
 
         this.getConfig(undefined, function(theConfig) {
             var recentPaths = [];
-            thisDoc.localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
+            localStorage.setItem("recent-docs", JSON.stringify(recentPaths));
             thisDoc.ipcClient.trigger("updateRecentPaths", recentPaths);
         });
     }

--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -319,6 +319,11 @@ var commands = {
     homepage: function (win, abrDoc, cm) {
         var homepageURL = constants.homepageURL;
         shell.openExternal(homepageURL);
+    },
+
+    clearRecentDocList: function (win, abrDoc, cm) {
+        //TODO recent-docs: clear
+        console.log("clearRecentDocList");
     }
 };
 

--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -322,7 +322,7 @@ var commands = {
     },
 
     clearRecentDocs: function(win, abrDoc, cm) {
-        // TODO recent-docs: clear recent docs menu
+        abrDoc.clearRecentDocs();
     },
 };
 

--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -323,6 +323,7 @@ var commands = {
 
     clearRecentDocList: function (win, abrDoc, cm) {
         //TODO recent-docs: clear
+        // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
         console.log("clearRecentDocList");
     }
 };

--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -319,12 +319,6 @@ var commands = {
     homepage: function (win, abrDoc, cm) {
         var homepageURL = constants.homepageURL;
         shell.openExternal(homepageURL);
-    },
-
-    clearRecentDocList: function (win, abrDoc, cm) {
-        //TODO recent-docs: clear
-        // See: https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#recent-documents-windows--macos
-        console.log("clearRecentDocList");
     }
 };
 

--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -319,7 +319,11 @@ var commands = {
     homepage: function (win, abrDoc, cm) {
         var homepageURL = constants.homepageURL;
         shell.openExternal(homepageURL);
-    }
+    },
+
+    clearRecentDocs: function(win, abrDoc, cm) {
+        // TODO recent-docs: clear recent docs menu
+    },
 };
 
 module.exports = commands;

--- a/app/renderer/main.js
+++ b/app/renderer/main.js
@@ -7,6 +7,6 @@
 var AbrDocument = require.main.require("./abr-document.js");
 
 $( function () {
-    var abrDoc = new AbrDocument();
+    var abrDoc = new AbrDocument(localStorage);
     window.abrDoc = abrDoc;
 });

--- a/app/renderer/main.js
+++ b/app/renderer/main.js
@@ -7,6 +7,6 @@
 var AbrDocument = require.main.require("./abr-document.js");
 
 $( function () {
-    var abrDoc = new AbrDocument(localStorage);
+    var abrDoc = new AbrDocument();
     window.abrDoc = abrDoc;
 });

--- a/default/config.json
+++ b/default/config.json
@@ -24,5 +24,9 @@
     },
     "window": {
         "showMenuBar": true
+    },
+    "recent-docs": {
+        "max": 5,
+        "files": []
     }
 }

--- a/default/config.json
+++ b/default/config.json
@@ -8,7 +8,8 @@
     },
     "autopreview-security": true,
     "editor": {
-        "font-size": "16px"
+        "font-size": "16px",
+        "max-recent": 5
     },
     "highlight-modes": "",
     "preview-template": "default",
@@ -24,9 +25,5 @@
     },
     "window": {
         "showMenuBar": true
-    },
-    "recent-docs": {
-        "max": 5,
-        "files": []
     }
 }

--- a/default/config.json
+++ b/default/config.json
@@ -8,9 +8,9 @@
     },
     "autopreview-security": true,
     "editor": {
-        "font-size": "16px",
-        "max-recent": 5
+        "font-size": "16px"
     },
+    "max-recent": 5,
     "highlight-modes": "",
     "preview-template": "default",
     "startup-commands": {


### PR DESCRIPTION
Fix for #69.

What's to be done:
- Store the recent docs list in the config (max length of this list is in the config, too),
- Recent docs list gets updated when the user opens or saves a file,
- Add a "File > Recent" menu that shows the recent docs' paths (clicking an item will open the file),
- Add a "File > Recent > Clear" menu to clear the recent docs list.
