### PR TITLE
Force "Save and close" button as default choice when closing unsaved document

### DIFF
--- a/app/dialogs.js
+++ b/app/dialogs.js
@@ -50,7 +50,8 @@ var appDialogs = {
             userChoice = dialog.showMessageBox(win, {
                 title: 'Unsaved document',
                 message: 'Do you really want to close \'' + filename + '\' without saving?',
-                buttons: ['Cancel', 'Save and close', 'Close without saving']
+                buttons: ['Cancel', 'Save and close', 'Close without saving'],
+                defaultId: 1
             });
         switch (userChoice) {
             case 1:


### PR DESCRIPTION
See #112 

I only made the default button change.
Not sure what's best about the labels, so I'll let you decide.
