### PR TITLE
Handlers for external changes or deletions

### DIFF
--- a/app/dialogs.js
+++ b/app/dialogs.js
@@ -123,12 +123,12 @@ var appDialogs = {
     askNeedSave: function (abrDoc, callback, win) {
         win = getWindow(win);
         var userChoice = dialog.showMessageBox(win, {
-                title: "Save Document",
-                message: "The current document needs to be saved before performing this operation.",
-                buttons: ["Cancel", "Save"],
-                defaultId: 1,
-                noLink: true
-            });
+            title: "Save Document",
+            message: "The current document needs to be saved before performing this operation.",
+            buttons: ["Cancel", "Save"],
+            defaultId: 1,
+            noLink: true
+        });
         if (userChoice === 1) {
             abrDoc.save(null, callback);
         }
@@ -160,9 +160,16 @@ var appDialogs = {
         });
     },
 
-    warnFileDeleted: function (path, callback) {
-        dialog.showErrorBox("Deleted file", "The file '" + path + "' doesn't exist anymore.");
-        callback();
+    warnFileDeleted: function (path, callback, win) {
+        win = getWindow(win);
+        var userChoice = dialog.showMessageBox(win, {
+            title: "Deleted file",
+            message: "The file '" + path + "' doesn't exist anymore. Keep this file in editor?",
+            buttons: ["Yes", "No"],
+            defaultId: 0,
+            noLink: true
+        });
+        callback(userChoice === 0);
     }
 };
 

--- a/app/dialogs.js
+++ b/app/dialogs.js
@@ -31,7 +31,7 @@ var appDialogs = {
             options = {
                 title: "About",
                 message: "ABRICOTINE - MARKDOWN EDITOR (v. " + constants.appVersion + ")\n\nCopyright (c) 2015 Thomas Brouard\n\nThis program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.",
-                buttons: ['OK'],
+                buttons: ["OK"],
                 icon: image,
                 noLink: true
             };
@@ -44,14 +44,14 @@ var appDialogs = {
 
     askClose: function (path, saveFunc, closeFunc, win) {
         if (!path) {
-            path = 'New document';
+            path = "New document";
         }
         win = getWindow(win);
         var filename = parsePath(path).basename || path,
             userChoice = dialog.showMessageBox(win, {
-                title: 'Unsaved document',
-                message: 'Do you really want to close \'' + filename + '\' without saving?',
-                buttons: ['Don\'t Save', 'Cancel', 'Save…'],
+                title: "Unsaved document",
+                message: "Do you really want to close '" + filename + "' without saving?",
+                buttons: ["Don't Save", "Cancel", "Save…"],
                 defaultId: 2,
                 noLink: true
             });
@@ -66,11 +66,23 @@ var appDialogs = {
         return false;
     },
 
+    askFileReload: function (path, callback, win) {
+        win = getWindow(win);
+        var userChoice = dialog.showMessageBox(win, {
+            title: "Changed file",
+            message: "The file '" + path + "' has been modified by another program. Do you want to reload it?",
+            buttons: ["Yes", "No"],
+            defaultId: 0,
+            noLink: true
+        });
+        callback(userChoice === 0);
+    },
+
     askOpenPath: function (title, win) {
         win = getWindow(win);
         var path = dialog.showOpenDialog(win, {
-            title: title || 'Open document',
-            properties: ['openFile'],
+            title: title || "Open document",
+            properties: ["openFile"],
             defaultPath: process.cwd()
         });
         if (path) {
@@ -82,7 +94,7 @@ var appDialogs = {
     askSavePath: function (title, win) {
         win = getWindow(win);
         var path = dialog.showSaveDialog(win, {
-            title: title || 'Save document',
+            title: title || "Save document",
             defaultPath: process.cwd()
         });
         if (path) {
@@ -94,9 +106,12 @@ var appDialogs = {
     askOpenImage: function (title, win) {
         win = getWindow(win);
         var path = dialog.showOpenDialog(win, {
-            title: title || 'Insert image',
-            properties: ['openFile'],
-            filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'gif', 'svg'] }],
+            title: title || "Insert image",
+            properties: ["openFile"],
+            filters: [{
+                name: "Images",
+                extensions: ["jpg", "jpeg", "png", "gif", "svg"]
+            }],
             defaultPath: process.cwd()
         });
         if (path) {
@@ -108,9 +123,9 @@ var appDialogs = {
     askNeedSave: function (abrDoc, callback, win) {
         win = getWindow(win);
         var userChoice = dialog.showMessageBox(win, {
-                title: 'Save document',
-                message: 'The current document needs to be saved before performing this operation.',
-                buttons: ['Cancel', 'Save'],
+                title: "Save document",
+                message: "The current document needs to be saved before performing this operation.",
+                buttons: ["Cancel", "Save"],
                 defaultId: 1,
                 noLink: true
             });
@@ -125,7 +140,7 @@ var appDialogs = {
         var userChoice = dialog.showMessageBox(win, {
             title: "Permission denied",
             message: "The file '" + path + "' could not be written: permission denied. Please choose another path.",
-            buttons: ['Cancel', 'OK'],
+            buttons: ["Cancel", "OK"],
             defaultId: 1,
             noLink: true
         });
@@ -140,9 +155,14 @@ var appDialogs = {
         dialog.showMessageBox(win, {
             title: "Images copied",
             message: "Document images have been copied in the '" + path + "' directory.",
-            buttons: ['OK'],
+            buttons: ["OK"],
             noLink: true
         });
+    },
+
+    warnFileDeleted: function (path, callback) {
+        dialog.showErrorBox("Deleted file", "The file '" + path + "' doesn't exist anymore.");
+        callback();
     }
 };
 

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -213,6 +213,9 @@ AbrDocument.prototype = {
         } else {
             closeFunc();
         }
+        if (this.watcher) {
+            this.watcher.close();
+        }
     },
 
     // Path
@@ -325,7 +328,7 @@ AbrDocument.prototype = {
         if (!path) {
             return this.saveAs(callback);
         }
-        // Pause to avoid triggering watcher callbacks.
+        // Pause the watcher to avoid triggering callbacks after saving the document
         this.pauseWatcher();
         var that = this,
             data = this.getData();

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -370,10 +370,12 @@ AbrDocument.prototype = {
         var that = this;
         this.watcher = files.createWatcher(this.path, {
             change: function (path) {
+                that.pauseWatcher();
                 dialogs.askFileReload(path, function (reloadRequired) {
                     if (reloadRequired) {
                         files.readFile(path, function (data, path) {
                             that.clear(data, path);
+                            that.startWatcher();
                         });
                     } else {
                         that.setDirty();
@@ -387,6 +389,7 @@ AbrDocument.prototype = {
                         that.setDirty();
                         that.updateWindowTitle();
                     } else {
+                        that.pauseWatcher();
                         that.clear();
                     }
                 });

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -262,6 +262,10 @@ AbrDocument.prototype = {
         this.latestGeneration = this.getGeneration();
     },
 
+    setDirty: function () {
+        this.latestGeneration--;
+    },
+
     isClean: function () {
         return this.cm.doc.isClean(this.latestGeneration);
     },
@@ -375,12 +379,14 @@ AbrDocument.prototype = {
                             that.clear(data, path);
                         });
                     } else {
+                        that.setDirty();
                         updateTitle();
                     }
                 });
             },
             unlink: function (path) {
                 dialogs.warnFileDeleted(path, function () {
+                    that.setDirty();
                     updateTitle();
                 });
             },

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -385,9 +385,13 @@ AbrDocument.prototype = {
                 });
             },
             unlink: function (path) {
-                dialogs.warnFileDeleted(path, function () {
-                    that.setDirty();
-                    updateTitle();
+                dialogs.warnFileDeleted(path, function (keepFile) {
+                    if (keepFile) {
+                        that.setDirty();
+                        that.updateWindowTitle();
+                    } else {
+                        that.clear();
+                    }
                 });
             },
             error: function (err) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@shagstrom/split-pane": "^0.9.2",
     "celldown.js": "latest",
+    "chokidar": "^1.6.1",
     "codemirror": "^5.15.2",
     "deep-equal": "^1.0.1",
     "electron-prebuilt": "^1.2.3",


### PR DESCRIPTION
Proposal for #94 

With this patch, Abricotine will display message boxes if the current file has been modified or deleted by a third party.
On changes, the user can choose to reload the file or leave it untouched.

In this case, or if the file was deleted, the document is forced to a "dirty" state to allow save, even on exit.

(Sorry about the noise with all the double quote changes)

![On change](http://imgur.com/cC2qSbg.png)

![On deletion](http://imgur.com/oew6zdf.png)