### PR TITLE
Don't steal focus after detecting file changes and deletions

### DIFF
--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -390,6 +390,8 @@ AbrDocument.prototype = {
                             that.startWatcher();
                         });
                     } else {
+                        // The previous document is dropped from the editor.
+                        // The watcher will resume on save.
                         that.setDirty();
                         that.updateWindowTitle();
                     }
@@ -399,8 +401,8 @@ AbrDocument.prototype = {
                     if (keepFile) {
                         that.setDirty();
                         that.updateWindowTitle();
+                        that.startWatcher();
                     } else {
-                        that.pauseWatcher();
                         that.clear();
                     }
                 });
@@ -408,10 +410,13 @@ AbrDocument.prototype = {
         };
         this.watcher = files.createWatcher(this.path, {
             change: function (path) {
+                // Pause the watcher to avoid triggering multiple warning dialogs
+                // while the first one is being handled.
                 that.pauseWatcher();
                 runOnFocus(handleAsyncFileChange, path);
             },
             unlink: function (path) {
+                that.pauseWatcher();
                 runOnFocus(handleAsyncFileChange, path);
             },
             error: function (err) {


### PR DESCRIPTION
Fixes #132.

Now the dialogs are displayed only when the app gets the focus back.

Also because it is an async matter now, when a dialog is about to be displayed, it checks if the file still exists or not.
For example, if the file is modified by a third-party, and then deleted, only the "Delete" dialog will show up.

---

Before submitting your PR please make sure:

* [x] You worked on the develop branch (or any other branch which was forked from develop),
* [x] Your PR is not targeting the master branch,
* [x] You tested your code and it works.

Thank you!
