### PR TITLE
Monospaced Headings & Code by default

### DIFF
--- a/default/themes/default-dark/theme.less
+++ b/default/themes/default-dark/theme.less
@@ -58,7 +58,7 @@
 // Headers
 .editor-headers() {
     color: #b0bcd0;
-    font-family: "Fira Code", Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
+    font-family: "Fira Code", "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", "Luxi Sans", sans-serif;
 }
 .editor-header-1() {
     font-size: 300%;

--- a/default/themes/default-dark/theme.less
+++ b/default/themes/default-dark/theme.less
@@ -58,7 +58,7 @@
 // Headers
 .editor-headers() {
     color: #b0bcd0;
-    font-family: "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", "Luxi Sans", sans-serif;
+    font-family: "Fira Code", Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
 }
 .editor-header-1() {
     font-size: 300%;
@@ -80,7 +80,7 @@
 }
 
 // Code
-@editor-code-font-family: "Courier New", Courier, "Liberation Mono", monospace;
+@editor-code-font-family: "Fira Code", "Courier New", Courier, "Liberation Mono", monospace;
 
 .editor-code() {
     color: #cc1e5c;

--- a/default/themes/default/theme.less
+++ b/default/themes/default/theme.less
@@ -58,7 +58,7 @@
 // Headers
 .editor-headers() {
     color: #000;
-    font-family: "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", "Luxi Sans", sans-serif;
+    font-family: "Fira Code", Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
 }
 .editor-header-1() {
     font-size: 300%;
@@ -80,7 +80,7 @@
 }
 
 // Code
-@editor-code-font-family: "Courier New", Courier, "Liberation Mono", monospace;
+@editor-code-font-family: "Fira Code", "Courier New", Courier, "Liberation Mono", monospace;
 
 .editor-code() {
     color: #3d2249;

--- a/default/themes/default/theme.less
+++ b/default/themes/default/theme.less
@@ -58,7 +58,7 @@
 // Headers
 .editor-headers() {
     color: #000;
-    font-family: "Fira Code", Monaco, "DejaVu Sans Mono", "Lucida Console", "Andale Mono", monospace;
+    font-family: "Fira Code", "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", "Luxi Sans", sans-serif;
 }
 .editor-header-1() {
     font-size: 300%;


### PR DESCRIPTION
Hi,
first of all - love the editor!

I think the titles, headings and code should also use Fira Code by default.

Advantages:
- Consistency
- Titles line up when using underline notation (see below)
- Fira Code Markdown-specific ligatures are used (Connected Octothorpes)
- Actual Code benefits from Code-specific ligatures (duh)

Disadvantages
- ???

Thank You for this great editor!