### PR TITLE
Allow users to add custom words to dictionary

### DIFF
--- a/app/menu-context.json
+++ b/app/menu-context.json
@@ -1,5 +1,12 @@
 [
     {
+        "labelKey": "menu-add-to-dictionary",
+        "command": "addToDict"
+    },
+    {
+        "type": "separator"
+    },
+    {
         "labelKey": "menu-undo",
         "accelerator": "CmdOrCtrl+Z",
         "role": "undo"

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -87,6 +87,17 @@ function AbrDocument () {
             // Spellchecker init
             if (config.spellchecker.active) {
                 that.setDictionary(config.spellchecker.language, config.spellchecker.src);
+
+                // custom words
+                var words = config.spellchecker["custom-words"];
+                if (words != null) {
+                    words.forEach(function (word) {
+                        // just for safety
+                        if (word != "") {
+                            spellchecker.add(word)
+                        }
+                    });
+                }
             }
 
             // Editor font-size

--- a/default/lang/en.json
+++ b/default/lang/en.json
@@ -1,4 +1,5 @@
 {
+    "menu-add-to-dictionary": "Add to Dictionary",
     "menu-undo": "Undo",
     "menu-redo": "Redo",
     "menu-cut": "Cut",


### PR DESCRIPTION
This PR adds the ability to right-click on a misspelled word and select "Add to Dictionary" to mark it as fine (fixes #243). It stores the custom words in the config file in this way:

```json
  "spellchecker": {
    "active": true,
    "language": "en_AU",
    "custom-words": [
      "aagadha",
      "sgdhsdgjsfg",
      "grsbtnh",
      "grsbtnhsbtj",
      "abcdef"
    ]
  },
```

The main questions I have with this PR as it exists are:

- Is the reloading custom words in `setDictionary` required? I think it's good to do so for safety's sake either way.
- Can the config file be reloaded while running Abricotine? If so, with the running list of custom words being stored in `this.words`, is there anywhere we'll need to re-load the words list from disk?
- Is there a better-supported way to reload the spellchecker highlighting than to run `abr-spellcheck-off` and then `abr-spellcheck-on`?
- Do we need a way to allow users to see the custom word list and remove from/add to it from a menu in Abricotine, or can we just tell them to edit the config file directly to do so?
- Is there a way to only display the "Add to Dictionary" context menu item when right-clicking on misspelled words? Right now it displays all the time.
- When the OS dictionary is in use (on at least macOS, maybe others), the custom words are stored in the macOS custom dictionary. This means we don't need to store or refresh the custom words list every load, and they won't be able to remove the custom words by just removing them from the Abricotine config file (see the `SpellChecker.add` note [here](https://github.com/atom/node-spellchecker/blob/master/README.md#spellcheckeraddword) for more info).

Thanks again for the awesome software, and hopefully this change looks decent! Feel free to rip me apart over it if it's not right – I'm pretty new to Node dev overall so happy to learn 😄

-------

* [x] You worked on the develop branch (or any other branch which was forked from develop),
* [x] Your PR is not targeting the master branch,
* [x] You tested your code and it works.