### PR TITLE
Added in Auto Save on Focus Lost

### DIFF
--- a/app/abr-window.js
+++ b/app/abr-window.js
@@ -106,6 +106,12 @@ AbrWindow.prototype = {
         win.on("focus", function () {
             abrWin.menu.attach();
         });
+        win.on("blur", function () {
+            var startupCommands = abrWin.config.get("startup-commands");
+            if (startupCommands.autoSaveOnFocusLost) {
+                abrWin.execCommand("autosave");
+            }
+        });
         win.on("closed", function () {
             // Destroy the window
             abrApp.windows[abrWin.id] = null;

--- a/app/menu-window.json
+++ b/app/menu-window.json
@@ -85,7 +85,7 @@
                 "labelKey": "menu-save-autosave",
                 "command": "autoSaveOnFocusLost",
                 "type": "checkbox",
-                "checked": "autosave_on_focus_lost"
+                "checked": "startup-commands:autoSaveOnFocusLost"
             },
             {
                 "type": "separator"

--- a/app/menu-window.json
+++ b/app/menu-window.json
@@ -82,6 +82,12 @@
                 "command": "saveAs"
             },
             {
+                "labelKey": "menu-save-autosave",
+                "command": "autoSaveOnFocusLost",
+                "type": "checkbox",
+                "checked": "autosave_on_focus_lost"
+            },
+            {
                 "type": "separator"
             },
             {

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -548,6 +548,15 @@ AbrDocument.prototype = {
         return this.save(path, callback);
     },
 
+    autosave: function(path, callback) {
+        path = path || this.path;
+        // Only autosave if it's an existing file
+        if (!path) {
+            return false;
+        }
+        return this.save(path, callback);
+    },
+
     initWatcher: function () {
         var that = this;
         // All dialogs should be displayed only if the window is focused.

--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -30,6 +30,10 @@ var commands = {
         abrDoc.saveAs();
     },
 
+    autosave: function(win, abrDoc, cm) {
+        abrDoc.autosave();
+    },
+
     exportHtml: function(win, abrDoc, cm, param) {
         abrDoc.exportHtml(param);
     },
@@ -142,6 +146,17 @@ var commands = {
         } else {
             // If cm not loaded yet
             abrDoc.commandsToTrigger.push("autoCloseBrackets");
+        }
+    },
+
+    autoSaveOnFocusLost: function(win, abrDoc, cm) {
+        if (cm) {
+            var flag = cm.getOption("autoSaveOnFocusLost");
+            cm.setOption("autoSaveOnFocusLost", !flag);
+            abrDoc.setConfig("startup-commands:autoSaveOnFocusLost", !flag);
+        } else {
+            // If cm not loaded yet
+            abrDoc.commandsToTrigger.push("autoSaveOnFocusLost");
         }
     },
 

--- a/default/config.json
+++ b/default/config.json
@@ -31,7 +31,8 @@
         "showBlocks": false,
         "showHiddenCharacters": true,
         "showTocPane": false,
-        "autoCloseBrackets": true
+        "autoCloseBrackets": true,
+        "autoSaveOnFocusLost" : false
     },
     "spellchecker": {
         "active": true,

--- a/default/lang/en.json
+++ b/default/lang/en.json
@@ -24,6 +24,7 @@
     "menu-open": "Open",
     "menu-save": "Save",
     "menu-save-as": "Save As…",
+    "menu-save-autosave": "Save on Focus Lost",
     "menu-export-html": "Export as HTML",
     "menu-close-document": "Close Document",
     "menu-close-window": "Close Window",


### PR DESCRIPTION
Added a toggle-able option to automatically save the file if Abricotine loses focus. 

- Will only save if the file has a valid path
- Added the toggle to the file menu
- This setting is defaulted to `false` 
- Uses the internal `save` method so it doesn't interrupt the file watcher

---

Before submitting your PR please make sure:

* [x] You worked on the develop branch (or any other branch which was forked from develop),
* [x] Your PR is not targeting the master branch,
* [x] You tested your code and it works.
