### PR TITLE
Upgrade is-url from 1.2.2 to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "electron-window-state": "5.0.3",
     "font-awesome": "4.7.0",
     "glob": "5.0.15",
-    "is-url": "1.2.2",
+    "is-url": "1.2.4",
     "jquery": "3.3.1",
     "kramed": "0.5.6",
     "langmap": "0.0.13",


### PR DESCRIPTION
`is-url 1.2.2` was vulnerable to a ReDoS attack. I upgraded the package to `is-url 1.2.4` to address the issue.

You can read more about the [vulnerability on Snyk](https://app.snyk.io/test/npm/is-url/1.2.2).

Before submitting your PR please make sure:

* [X] You worked on the develop branch (or any other branch which was forked from develop),
* [X] Your PR is not targeting the master branch,
* [ ] You tested your code and it works.

Thank you!
