### PR TITLE
Added missing error handler when cleaning temporary resources

### DIFF
--- a/app/abr-application.js
+++ b/app/abr-application.js
@@ -143,7 +143,11 @@ AbrApplication.prototype = {
 
     emptyTmpHTML: function () {
         var path = constants.path.tmp + "/!(themes)";
-        files.rm(path);
+        files.rm(path, error => {
+            if (error) {
+                console.error(`Could not delete file at ${error.path}`, error);
+            }
+        });
     }
 };
 


### PR DESCRIPTION
Fixes #256 

Added the missing error handler function when cleaning temporary resources.

Let me know if you want me to get rid of the arrow function and use the regular one.

*Checklist*:

* [x] You worked on the develop branch (or any other branch which was forked from develop),
* [x] Your PR is not targeting the master branch,
* [x] You tested your code and it works.
