### PR TITLE
Add `-s` option to default pandoc task.

### DIFF
--- a/default/config.json
+++ b/default/config.json
@@ -43,7 +43,7 @@
     "tasks": [
         {
             "name": "Export with Pandoc",
-            "exec": "pandoc %inputFilepath% -o %outputFilepath%"
+            "exec": "pandoc -s %inputFilepath% -o %outputFilepath%"
         }
     ],
     "theme": "default",


### PR DESCRIPTION
Pandoc will only produce snippets by default for most formats.
I believe the default behaviour for exporting from Abricotine
should be producing standalone documents. Supplying the `-s`
option will instruct pandoc to produce complete documents.