### PR TITLE
Let Abricotine open local links

### DIFF
--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -16,6 +16,7 @@ var remote = require("electron").remote,
     files = remote.require("./files.js"),
     loadTheme = require.main.require("./load-theme.js"),
     Localizer = remote.require("./localize.js"),
+    fs = require("fs"),
     parsePath = require("parse-filepath"),
     pathModule = require("path"),
     shell = require("electron").shell,
@@ -290,6 +291,12 @@ function AbrDocument () {
                     }
 
                     if (url === "") return;
+                    if (!fs.existsSync(url)) {
+                        var hasProtocol = /^[a-z]+:\/\//.test(url);
+                        if (!hasProtocol) {
+                          url = "http://" + url;
+                        }
+                    }
                     const openLink = shell.openPath || shell.openItem;
                     openLink(url);
                 };

--- a/app/renderer/abr-document.js
+++ b/app/renderer/abr-document.js
@@ -290,11 +290,8 @@ function AbrDocument () {
                     }
 
                     if (url === "") return;
-                    var hasProtocol = /^[a-z]+:\/\//.test(url);
-                    if (!hasProtocol) {
-                      url = "http://" + url;
-                    }
-                    shell.openExternal(url);
+                    const openLink = shell.openPath || shell.openItem;
+                    openLink(url);
                 };
 
                 // Handle CTRL+MouseWheel events


### PR DESCRIPTION
Proposal to implement feature requested in #303. `shell.openItem` (`shell.openPath` in newer versions of electron) generalizes `shell.openExternal` and lets the OS open local links using the appropriate application. URLs will still open as they do now, but this will also allow links to pictures, pdfs, or indeed other markdown files to open in the same way.

Tested on Ubuntu 20.04 against these test cases:

1. **\[absolute path](/home/\<user>/abricotine/README.md)** - OPENS CORRECTLY
2. **\[relative path](abricotine/README.md)** - OPENS CORRECTLY
3. **\[empty path]()** - NOTHING OPENS AS EXPECTED
4. **\[website](https://github.com/brrd/Abricotine)** - OPENS CORRECTLY
5. **\[website no proto](github.com/brrd/Abricotine)** - OPENS CORRECTLY
6. **\[bad path](nonexistent-nonsense)** - NOTHING OPENS AS EXPECTED